### PR TITLE
Ensure srun happens in the right environment

### DIFF
--- a/1_turb_abl_fsi/template_files/eagle_aprepro.txt
+++ b/1_turb_abl_fsi/template_files/eagle_aprepro.txt
@@ -10,4 +10,4 @@
 #SBATCH -N 70
 #SBATCH --qos=high'}
 
-# {SRUN_COMMAND = 'srun -n 2520 exawind --nwind 540 --awind 1980 nrel5mw.yaml &> driver.log'}
+# {SRUN_COMMAND = 'spack build-env exawind srun -n 2520 exawind --nwind 540 --awind 1980 nrel5mw.yaml &> driver.log'}

--- a/1_turb_abl_fsi/template_files/frontier_aprepro.txt
+++ b/1_turb_abl_fsi/template_files/frontier_aprepro.txt
@@ -17,5 +17,5 @@ export=FI_CXI_RX_MATCH_MODE=software'}
 #SBATCH --ntasks-per-node=8
 #SBATCH --exclusive'}
 
-# {SRUN_COMMAND = 'srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
+# {SRUN_COMMAND = 'spack build-env exawind srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
 

--- a/1_turb_uni_fsi/template_files/eagle_aprepro.txt
+++ b/1_turb_uni_fsi/template_files/eagle_aprepro.txt
@@ -10,4 +10,4 @@
 #SBATCH -N 70
 #SBATCH --qos=high'}
 
-# {SRUN_COMMAND = 'srun -n 2520 exawind --nwind 540 --awind 1980 nrel5mw.yaml &> driver.log'}
+# {SRUN_COMMAND = 'spack build-env exawind srun -n 2520 exawind --nwind 540 --awind 1980 nrel5mw.yaml &> driver.log'}

--- a/1_turb_uni_fsi/template_files/frontier_aprepro.txt
+++ b/1_turb_uni_fsi/template_files/frontier_aprepro.txt
@@ -17,5 +17,5 @@ export=FI_CXI_RX_MATCH_MODE=software'}
 #SBATCH --ntasks-per-node=8
 #SBATCH --exclusive'}
 
-# {SRUN_COMMAND = 'srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
+# {SRUN_COMMAND = 'spack build-env exawind srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
 

--- a/4_turb_abl_fsi/template_files/frontier_aprepro.txt
+++ b/4_turb_abl_fsi/template_files/frontier_aprepro.txt
@@ -17,6 +17,6 @@ export=FI_CXI_RX_MATCH_MODE=software'}
 #SBATCH --ntasks-per-node=8
 #SBATCH --exclusive'}
 
-# {SRUN_COMMAND_OPENFAST = 'srun -N 1 -n 4 openfastcpp inp.yaml'}
-# {SRUN_COMMAND_EXAWIND = 'srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
+# {SRUN_COMMAND_OPENFAST = 'spack build-env openfast srun -N 1 -n 4 openfastcpp inp.yaml'}
+# {SRUN_COMMAND_EXAWIND = 'spack build-env exawind srun -N 272 -n 2176 --gpus-per-node=8 --gpu-bind=closest  exawind --awind 2048 --nwind 128 nrel5mw.yaml'}
 


### PR DESCRIPTION
With an interactive node I found that I could get the correct behavior when I made sure to initialize the `srun` command inside the spack build environment for `exawind`. The working hypothesis is the PrgEnv was inconsistent when just running `srun` without manipulating all the modules. 

What tipped this off is a fortran lib load error when trying to run with an older build.
When I switched to using `spack build-env exawind` as in this PR the linear solvers started converging.

This leads me to believe that the failing cases were getting the incorrect but psuedo-compatible libraries loaded via the PrgEnv and that was causing the linear solvers to tank in nalu-wind.