### PR TITLE
Run Frontier Scripts

### DIFF
--- a/4_turb_abl_rigid/run-frontier.sh
+++ b/4_turb_abl_rigid/run-frontier.sh
@@ -7,6 +7,8 @@
 #SBATCH -S 0
 #SBATCH -N 64
 
+set -e
+
 cmd() {
   echo "+ $@"
   eval "$@"
@@ -15,20 +17,11 @@ cmd() {
 SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
 EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/shared
-
 spec="exawind"
 
 cmd "module load cray-python"
 cmd "source ${EXAWIND_MANAGER}/start.sh && spack-start"
 cmd "spack env activate ${SPACK_ENV_NAME}"
-mods=$(spack build-env "$spec" | grep 'LOADEDMODULES' | cut -d'=' -f2)
-IFS=':' read -r -a modules <<< "$mods"
-for module in "${modules[@]}"; do
-    # Check if the module is already loaded
-    if ! module list 2>&1 | grep -q "$module"; then
-        cmd "module load "$module""
-    fi
-done
 cmd "spack load ${spec}"
 cmd "which exawind"
 
@@ -57,4 +50,4 @@ AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
 NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
 TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
 
-cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"
+cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest spack build-env exawind exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"

--- a/4_turb_abl_rigid/run-frontier.sh
+++ b/4_turb_abl_rigid/run-frontier.sh
@@ -1,12 +1,11 @@
 #!/bin/bash -l
 
-#SBATCH -J single-turbine
+#SBATCH -J 4_turb_abl_rigid
 #SBATCH -o %x.o%j
 #SBATCH -A CFD162
 #SBATCH -t 30
-#SBATCH -q debug
 #SBATCH -S 0
-#SBATCH -N 4
+#SBATCH -N 64
 
 set -e
 
@@ -42,7 +41,10 @@ cmd "export FI_CXI_RX_MATCH_MODE=software"
 cmd "export MPICH_SMP_SINGLE_COPY_MODE=NONE"
 
 #Update mesh path
-sed -i "s|CHANGE_PATH|${MESH_PATH}|g" nrel5mw_nalu.yaml || true
+set +e
+find . -name 'nrel5mw_nalu_w_tower*.yaml' -type f -exec sed -i "s|CHANGE_PATH|${MESH_PATH}|g" {} \;
+find . -name 'nrel5mw_amr.inp' -type f -exec sed -i "s|CHANGE_PATH|${MESH_PATH}|g" {} \;
+set -e
 
 #+amr_wind_gpu~nalu_wind_gpu
 cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"

--- a/4_turb_abl_rigid/run-frontier.sh
+++ b/4_turb_abl_rigid/run-frontier.sh
@@ -7,18 +7,15 @@
 #SBATCH -S 0
 #SBATCH -N 64
 
-set -e
-
 cmd() {
   echo "+ $@"
   eval "$@"
 }
 
-SPACK_ENV_NAME=exawind_frontier_01_30_2025
+SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
 EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/shared
 
-#spec="exawind+amr_wind_gpu~nalu_wind_gpu"
 spec="exawind"
 
 cmd "module load cray-python"
@@ -47,17 +44,17 @@ find . -name 'nrel5mw_amr.inp' -type f -exec sed -i "s|CHANGE_PATH|${MESH_PATH}|
 set -e
 
 #+amr_wind_gpu~nalu_wind_gpu
-cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
-AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
-NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
-TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
-cmd "export MPICH_RANK_REORDER_METHOD=3"
-cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
+#cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
+#AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
+#NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
+#TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
+#cmd "export MPICH_RANK_REORDER_METHOD=3"
+#cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
 
 #+amr_wind_gpu+nalu_wind_gpu
-#cmd "export HIP_LAUNCH_BLOCKING=1"
-#AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
-#NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
-#TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
+cmd "export HIP_LAUNCH_BLOCKING=1"
+AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
 
 cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"

--- a/4_turb_abl_rigid/run-frontier.sh
+++ b/4_turb_abl_rigid/run-frontier.sh
@@ -15,7 +15,7 @@ cmd() {
 }
 
 SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
-EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
+export EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/shared
 spec="exawind"
 

--- a/single-turbine/run-frontier.sh
+++ b/single-turbine/run-frontier.sh
@@ -6,7 +6,7 @@
 #SBATCH -t 30
 #SBATCH -q debug
 #SBATCH -S 0
-#SBATCH -N 2
+#SBATCH -N 4
 
 set -e
 
@@ -15,18 +15,48 @@ cmd() {
   eval "$@"
 }
 
-SPACK_ENV_NAME=exawind-frontier
+SPACK_ENV_NAME=exawind_01_29_2025
+EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager-builds/exawind-manager/
 MESH_PATH=${PROJWORK}/cfd162/shared
 
-cmd "module load PrgEnv-amd/8.5.0"
-cmd "module load amd/6.0.0"
-cmd "module load cray-mpich/8.1.27"
 cmd "module load cray-python"
-cmd "export EXAWIND_MANAGER=${PROJWORK}/cfd162/${USER}/exawind-manager"
 cmd "source ${EXAWIND_MANAGER}/start.sh && spack-start"
 cmd "spack env activate ${SPACK_ENV_NAME}"
-cmd "spack load exawind+amr_wind_gpu+nalu_wind_gpu"
-cmd "which exawind"
+cmd "module purge"
+
+#load_packages=("exawind", "amr-wind", "nalu-wind") #uncomment to only load specific root packages 
+root_specs=$(spack find | grep '[+]' | cut -d' ' -f2) #get root spec names from spack find
+# Loop through all packages
+for package in $root_specs; do
+    loaded=false
+    # If load_packages is undefined, load all root specs
+    if [ ${#load_packages[@]} -eq 0 ]; then
+        cmd "spack load "$package""
+        loaded=true
+
+    # Else, only load packages in load_packages variable 
+    else
+        for load_package in "${load_packages[@]}"; do
+            if [[ "$package" == *"$load_package"* ]]; then
+                cmd "spack load "$package""
+                loaded=true
+                break
+            fi
+        done
+    fi
+
+    # Load all modules for each package from the build environment
+    if [ "$loaded" = true ]; then
+        mods=$(spack build-env "$package" | grep 'LOADEDMODULES' | cut -d'=' -f2)
+        IFS=':' read -r -a modules <<< "$mods"
+        for module in "${modules[@]}"; do
+            # Check if the module is already loaded
+            if ! module list 2>&1 | grep -q "$module"; then
+                cmd "module load "$module""
+            fi
+        done
+    fi
+done
 
 #Current possibly necessary exports
 cmd "export FI_MR_CACHE_MONITOR=memhooks"

--- a/single-turbine/run-frontier.sh
+++ b/single-turbine/run-frontier.sh
@@ -8,24 +8,22 @@
 #SBATCH -S 0
 #SBATCH -N 4
 
-set -e
-
+#set -e
 cmd() {
   echo "+ $@"
   eval "$@"
 }
-
-SPACK_ENV_NAME=exawind_frontier_01_30_2025
+SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
 EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/shared
-
-#spec="exawind+amr_wind_gpu~nalu_wind_gpu"
 spec="exawind"
 
 cmd "module load cray-python"
 cmd "source ${EXAWIND_MANAGER}/start.sh && spack-start"
 cmd "spack env activate ${SPACK_ENV_NAME}"
+cmd "module purge"
 mods=$(spack build-env "$spec" | grep 'LOADEDMODULES' | cut -d'=' -f2)
+echo $mods
 IFS=':' read -r -a modules <<< "$mods"
 for module in "${modules[@]}"; do
     # Check if the module is already loaded
@@ -45,17 +43,17 @@ cmd "export MPICH_SMP_SINGLE_COPY_MODE=NONE"
 sed -i "s|CHANGE_PATH|${MESH_PATH}|g" nrel5mw_nalu.yaml || true
 
 #+amr_wind_gpu~nalu_wind_gpu
-cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
-AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
-NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
-TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
-cmd "export MPICH_RANK_REORDER_METHOD=3"
-cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
+#cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
+#AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
+#NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
+#TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
+#cmd "export MPICH_RANK_REORDER_METHOD=3"
+#cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
 
 #+amr_wind_gpu+nalu_wind_gpu
-#cmd "export HIP_LAUNCH_BLOCKING=1"
-#AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
-#NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
-#TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
+cmd "export HIP_LAUNCH_BLOCKING=1"
+AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
 
 cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"

--- a/single-turbine/run-frontier.sh
+++ b/single-turbine/run-frontier.sh
@@ -8,29 +8,21 @@
 #SBATCH -S 0
 #SBATCH -N 4
 
-#set -e
+set -e
+
 cmd() {
   echo "+ $@"
   eval "$@"
 }
+
 SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
-EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
+export EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/shared
 spec="exawind"
 
 cmd "module load cray-python"
 cmd "source ${EXAWIND_MANAGER}/start.sh && spack-start"
 cmd "spack env activate ${SPACK_ENV_NAME}"
-cmd "module purge"
-mods=$(spack build-env "$spec" | grep 'LOADEDMODULES' | cut -d'=' -f2)
-echo $mods
-IFS=':' read -r -a modules <<< "$mods"
-for module in "${modules[@]}"; do
-    # Check if the module is already loaded
-    if ! module list 2>&1 | grep -q "$module"; then
-        cmd "module load "$module""
-    fi
-done
 cmd "spack load ${spec}"
 cmd "which exawind"
 
@@ -56,4 +48,4 @@ AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
 NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
 TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
 
-cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"
+cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest spack build-env exawind exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} nrel5mw.yaml"

--- a/sphere/run-frontier.sh
+++ b/sphere/run-frontier.sh
@@ -2,21 +2,19 @@
 
 #SBATCH -o %x.o%j
 #SBATCH -A CFD162
-#SBATCH -t 00:30:00
+#SBATCH -t 01:30:00
 #SBATCH -q debug
 #SBATCH -S 0
 #SBATCH -J sphere
 #SBATCH -N 4
 
-set -e
-
+#set -e
 cmd() {
   echo "+ $@"
   eval "$@"
 }
 
-
-SPACK_ENV_NAME=exawind_frontier_01_30_2025
+SPACK_ENV_NAME=exawind_frontier_gpu_02_05_2025
 EXAWIND_MANAGER=${MEMBERWORK}/cfd162/exawind-manager
 MESH_PATH=${PROJWORK}/cfd162/gyalla/exawind-cases/sphere/
 
@@ -45,12 +43,18 @@ cmd "export MPICH_SMP_SINGLE_COPY_MODE=NONE"
 sed -i "s|CHANGE_PATH|${MESH_PATH}|g" sphere-nalu.yaml || true
 
 #+amr_wind_gpu~nalu_wind_gpu
-cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
-AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
-NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
-TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
-cmd "export MPICH_RANK_REORDER_METHOD=3"
-cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
+#cmd "python3 ../tools/reorder_file.py ${SLURM_JOB_NUM_NODES}"
+#AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
+#NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*56))
+#TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*64))
+#cmd "export MPICH_RANK_REORDER_METHOD=3"
+#cmd "export MPICH_RANK_REORDER_FILE=exawind.reorder_file"
+
+#+amr_wind_gpu+nalu_wind_gpu
+cmd "export HIP_LAUNCH_BLOCKING=1"
+AWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+NWIND_RANKS=$((${SLURM_JOB_NUM_NODES}*4))
+TOTAL_RANKS=$((${SLURM_JOB_NUM_NODES}*8))
 
 cmd "srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_RANKS} --gpus-per-node=8 --gpu-bind=closest exawind --awind ${AWIND_RANKS} --nwind ${NWIND_RANKS} sphere.yaml"
 

--- a/sphere/run-frontier.sh
+++ b/sphere/run-frontier.sh
@@ -2,7 +2,7 @@
 
 #SBATCH -o %x.o%j
 #SBATCH -A CFD162
-#SBATCH -t 00:30:00
+#SBATCH -t 01:00:00
 #SBATCH -q debug
 #SBATCH -S 0
 #SBATCH -J sphere


### PR DESCRIPTION
Updating scripts to run cases on Frontier including 

- [x] single-turbine 
- [x] sphere
- [x] 4_turb_abl_rigid
- [ ] 16_turb_abl_rigid

For each case, the modules to load are automatically pulled from the spack build environment for consistency. Also using consistent naming between cases. 


